### PR TITLE
Update license tests to resolve failures

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -10,4 +10,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(pyklatchat|neon|tqdm|RapidFuzz|typing_extensions).*'
+      packages-exclude: '^(pyklatchat|neon|tqdm|RapidFuzz|typing_extensions|urllib|setuptools|click|paramiko).*'


### PR DESCRIPTION
# Description
Update license tests to whitelist permissively licensed packages and paramiko
Paramiko carries an LGPL license, but is used directly as a dependency without modification to the functionality it implements

# Issues
Addresses test failures in #1

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->